### PR TITLE
Fix local player pointer randomly becoming corrupted after spawning an item

### DIFF
--- a/source/game/game_state.h
+++ b/source/game/game_state.h
@@ -55,6 +55,7 @@ struct game_state {
 	struct camera camera;
 	struct camera_ray_result camera_hit;
 	struct world world;
+	uint32_t local_player_id;
 	struct entity* local_player;
 	dict_entity_t entities;
 	uint64_t world_time;

--- a/source/network/client_interface.c
+++ b/source/network/client_interface.c
@@ -129,6 +129,7 @@ void clin_process(struct client_rpc* call) {
 
 			gstate.local_player = dict_entity_safe_get(
 				gstate.entities, call->payload.world_reset.local_entity);
+			gstate.local_player_id = call->payload.world_reset.local_entity;
 			entity_local_player(call->payload.world_reset.local_entity,
 								gstate.local_player, &gstate.world);
 
@@ -221,6 +222,8 @@ void clin_process(struct client_rpc* call) {
 		case CRPC_SPAWN_ITEM: {
 			struct entity* e = dict_entity_safe_get(
 				gstate.entities, call->payload.spawn_item.entity_id);
+			gstate.local_player = dict_entity_safe_get(
+				gstate.entities, gstate.local_player_id);
 			entity_item(call->payload.spawn_item.entity_id, e, false,
 						&gstate.world, call->payload.spawn_item.item);
 			e->teleport(e, call->payload.spawn_item.pos);


### PR DESCRIPTION
Client-side entitites are tracked with an M*LIB dictionary, and inserting a new entity can [shuffle other entities around in memory](https://github.com/P-p-H-d/mlib?tab=readme-ov-file#m-dict), including the local player:

> Elements in the dictionary are **unordered**. On insertion of a new element, contained objects may moved.

Therefore, insertion of a new entity can randomly make `gstate.local_player` point to garbage data, usually getting the player stuck at X=0, Y=0 and Z=0, sometimes ending in a segmentation fault.

To fix it, I added a variable separate from the entity dictionary which tracks the local player ID, allowing updating `gstate.local_player` after spawning a new entity. As long as the game is singleplayer, the local player ID is always 0, but the variable may be useful when multiplayer is added.