### PR TITLE
Fix missing usleep declaration on Wii by adding feature macros and unistd.h include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ INCLUDES	:=
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS		=	-std=c99 -pedantic -Wextra -Wno-unused-parameter -flto=auto -O3 -Wall -DNDEBUG -DPLATFORM_WII $(MACHDEP) $(INCLUDE)
+CFLAGS		=	-std=c99 -pedantic -Wextra -Wno-unused-parameter -flto=auto -O3 -Wall -DNDEBUG -DPLATFORM_WII $(MACHDEP) $(INCLUDE) -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600
 CXXFLAGS	=	$(CFLAGS)
 
 LDFLAGS	=	$(MACHDEP) -Wl,-Map,$(notdir $@).map

--- a/source/platform/thread.h
+++ b/source/platform/thread.h
@@ -43,6 +43,7 @@ struct thread_channel {
 
 #ifdef PLATFORM_WII
 #include <gccore.h>
+#include <unistd.h>
 
 struct thread {
 	lwp_t native;


### PR DESCRIPTION
The project would not compile on my machine. This also probably fixes the issue #75 